### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.0.1
+          uses: docker/build-push-action@v6.0.2
           with:
             context: .
             platforms: linux/arm/v7


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.0.2](https://github.com/docker/build-push-action/releases/tag/v6.0.2)** on 2024-06-20T13:57:31Z
