### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
           # Add support for more platforms with QEMU (optional)
           # https://github.com/docker/setup-qemu-action
           name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
+          uses: docker/setup-qemu-action@v3.1.0
         -
           name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.3.0
+          uses: docker/setup-buildx-action@v3.4.0
         -
           name: Login to DockerHub
           uses: docker/login-action@v3.2.0
@@ -46,7 +46,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.0.1
+          uses: docker/build-push-action@v6.3.0
           with:
             context: .
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.1.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.1.0)** on 2024-07-03T11:26:55Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.4.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.4.0)** on 2024-07-04T07:35:04Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.3.0](https://github.com/docker/build-push-action/releases/tag/v6.3.0)** on 2024-07-03T07:47:10Z
